### PR TITLE
Fix onToggleOpen

### DIFF
--- a/src/Drawer/useDrawer.tsx
+++ b/src/Drawer/useDrawer.tsx
@@ -21,9 +21,9 @@ export const useDrawer = (prop?: DrawerOptions) => {
     onClose?.();
   }, [onClose]);
 
-  const onToggleOpen = useCallback(() => {
-    setInternalOpen(!open);
-  }, []);
+  const onToggleOpen = () => {
+    setInternalOpen(!internalOpen);
+  };
 
   const Component = useCallback(
     (props: Partial<DrawerProps>) => (


### PR DESCRIPTION
`React.useCallback` [Returns a memoized callback.](https://reactjs.org/docs/hooks-reference.html#usecallback) `onToggleOpen` depending on `internalOpen` , hence `onToggleOpen` shouldn't be memoized.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Can not use `toggleOpen` to close `Drawer` .


## What is the new behavior?

Can use `toggleOpen` to close `Drawer` .

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
