### PR TITLE
differentiate between popover and tooltip refs in state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realayers",
-  "version": "3.0.4",
+  "version": "3.1.0",
   "description": "Layer Components for React - Dialogs, Drawers, Tooltips, Popovers",
   "scripts": {
     "build": "rollup -c",

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -43,6 +43,7 @@ export const Popover: FC<PopoverProps> = ({
       trigger={trigger}
       pointerEvents="initial"
       leaveDelay={leaveDelay}
+      isPopover
       className={classNames(css.popover, {
         [css.disablePadding]: disablePadding
       })}

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -137,8 +137,8 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
   const [internalVisible, setInternalVisible] = useState<boolean>(visible);
   const timeout = useRef<any | null>(null);
   const mounted = useRef<boolean>(false);
-  const ref = useRef<(setter: boolean) => boolean>(
-    (vis: boolean, isPop?: boolean) => {
+  const ref = useRef<(setter: boolean, isPop?: boolean) => boolean>(
+    (vis, isPop) => {
       // Since Popovers use the Tooltip component and they share state, need to differentiate between
       // Popovers and Tooltips so one does not deactivate the other
       if (isPop === isPopover) {

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -102,6 +102,11 @@ export interface TooltipProps {
    * Add pointer events or not. Usually not for tooltips.
    */
   pointerEvents?: string;
+
+  /**
+   * Differentiator for popovers to be handled separate from tooltips
+   */
+  isPopover?: boolean;
 }
 
 export const Tooltip: FC<Partial<TooltipProps>> = ({
@@ -120,15 +125,30 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
   closeOnEscape,
   closeOnBodyClick,
   pointerEvents,
+  isPopover,
   ...rest
 }) => {
-  const { addTooltip, deactivateTooltip, deactivateAllTooltips } =
-    useTooltipState();
+  const {
+    addTooltip,
+    deactivateTooltip,
+    deactivateAllTooltips
+  } = useTooltipState();
 
   const [internalVisible, setInternalVisible] = useState<boolean>(visible);
   const timeout = useRef<any | null>(null);
   const mounted = useRef<boolean>(false);
-  const ref = useRef<(setter: boolean) => void>(setInternalVisible);
+  const ref = useRef<(setter: boolean) => boolean>(
+    (vis: boolean, isPop?: boolean) => {
+      // Since Popovers use the Tooltip component and they share state, need to differentiate between
+      // Popovers and Tooltips so one does not deactivate the other
+      if (isPop === isPopover) {
+        setInternalVisible(vis);
+      }
+
+      // Return whether the ref's state was updated
+      return isPop === isPopover;
+    }
+  );
 
   useEffect(() => {
     // componentDidUpdateLogic style logic
@@ -142,7 +162,7 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
     const timer = timeout.current;
     return () => {
       clearTimeout(timer);
-      deactivateTooltip(curRef);
+      deactivateTooltip(curRef, isPopover);
     };
   }, [deactivateTooltip, visible]);
 
@@ -187,7 +207,7 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
             exit={{ opacity: 0, scale: 0.3 }}
             onClick={() => {
               if (closeOnClick) {
-                deactivateAllTooltips();
+                deactivateAllTooltips(isPopover);
               }
             }}
           >
@@ -200,7 +220,7 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
           clearTimeout(timeout.current);
           timeout.current = setTimeout(() => {
             if (!disabled) {
-              deactivateAllTooltips();
+              deactivateAllTooltips(isPopover);
               setInternalVisible(true);
               addTooltip(ref.current);
             }
@@ -210,7 +230,7 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
       onClose={() => {
         clearTimeout(timeout.current);
         timeout.current = setTimeout(() => {
-          deactivateTooltip(ref.current);
+          deactivateTooltip(ref.current, isPopover);
         }, leaveDelay);
       }}
     >

--- a/src/Tooltip/useTooltipState.ts
+++ b/src/Tooltip/useTooltipState.ts
@@ -4,24 +4,35 @@ import { useEffect, useState } from 'react';
  * Creates a global state singleton.
  */
 const createStateHook = () => {
-  let tooltips: ((setter: boolean) => void)[] = [];
+  let tooltips: ((setter: boolean, isPopover?: boolean) => boolean)[] = [];
 
   function addTooltip(newTip: any) {
     tooltips = [...tooltips, newTip];
   }
 
-  function deactivateTooltip(tooltip) {
+  function deactivateTooltip(tooltip, isPopover?: boolean) {
     const idx = tooltips.indexOf(tooltip);
     if (idx > -1) {
       const tip = tooltips[idx];
-      tip(false);
-      tooltips.splice(idx, 1);
+      const shouldRemove = tip(false, isPopover);
+      if (shouldRemove) {
+        tooltips.splice(idx, 1);
+      }
     }
   }
 
-  function deactivateAllTooltips() {
-    tooltips.forEach(ref => ref(false));
-    tooltips = [];
+  function deactivateAllTooltips(isPopover?: boolean) {
+    const newTooltips = [];
+
+    tooltips.forEach(ref => {
+      const shouldRemvoe = ref(false, isPopover);
+
+      if (!shouldRemvoe) {
+        newTooltips.push(ref);
+      }
+    });
+
+    tooltips = [...newTooltips];
   }
 
   return () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When both a Popover and a Tooltip are used on the same component, hovering over an element with a Tooltip while a Popover is open will hide the Popover
Issue Number: N/A


## What is the new behavior?
Differentiate between Popover refs and Tooltip refs in the Tooltip's useTooltipState hook. This allows the Popover refs to not be deactivated when opening a Tooltip.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

https://user-images.githubusercontent.com/6655992/177436493-7298ad11-f37b-4d62-a007-fb1f993fb8c7.mov


