### PR TITLE
allow menu to have the same width as the reference

### DIFF
--- a/src/Menu/Menu.story.tsx
+++ b/src/Menu/Menu.story.tsx
@@ -103,7 +103,7 @@ export const Nested = () => {
   );
 };
 
-export const ReferenceWidth = () => {
+export const AutoWidth = () => {
   const { toggleOpen, ref, Menu: MenuComponent } = useMenu();
 
   return (
@@ -116,7 +116,7 @@ export const ReferenceWidth = () => {
       >
         Open
       </button>
-      <MenuComponent style={{ background: 'white' }} sameReferenceWidth>
+      <MenuComponent style={{ background: 'white' }} autoWidth>
         <h3>My Menu</h3>
         <ul>
           <li>Austin</li>

--- a/src/Menu/Menu.story.tsx
+++ b/src/Menu/Menu.story.tsx
@@ -102,3 +102,28 @@ export const Nested = () => {
     </Fragment>
   );
 };
+
+export const ReferenceWidth = () => {
+  const { toggleOpen, ref, Menu: MenuComponent } = useMenu();
+
+  return (
+    <Fragment>
+      <button
+        type="button"
+        ref={ref}
+        onClick={toggleOpen}
+        style={{ width: '300px' }}
+      >
+        Open
+      </button>
+      <MenuComponent style={{ background: 'white' }} sameReferenceWidth>
+        <h3>My Menu</h3>
+        <ul>
+          <li>Austin</li>
+          <li>Mark</li>
+          <li>Jack</li>
+        </ul>
+      </MenuComponent>
+    </Fragment>
+  );
+};

--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -2,6 +2,7 @@ import React, { FC, forwardRef, Ref, useMemo } from 'react';
 import classNames from 'classnames';
 import FocusTrap from 'focus-trap-react';
 import { ConnectedOverlay, OverlayEvent, Placement, useId } from 'rdk';
+import { Modifiers } from 'popper.js';
 import { motion } from 'framer-motion';
 import css from './Menu.module.css';
 
@@ -64,12 +65,22 @@ export interface MenuProps {
   /**
    * Popper.js Position modifiers.
    */
-  modifiers?: any;
+  modifiers?: Modifiers[];
 
   /**
    * Whether the menu should be the same width as the reference element
    */
-  sameReferenceWidth?: boolean;
+  autoWidth?: boolean;
+
+  /**
+   * Min width of the menu.
+   */
+  minWidth?: number;
+
+  /**
+   * Max width of the menu.
+   */
+  maxWidth?: number;
 
   /**
    * Menu was closed.
@@ -104,7 +115,9 @@ export const Menu: FC<
       maxHeight,
       autofocus,
       modifiers,
-      sameReferenceWidth,
+      autoWidth,
+      minWidth,
+      maxWidth,
       onClose,
       onMouseEnter,
       onMouseLeave
@@ -114,7 +127,7 @@ export const Menu: FC<
     const id = useId();
 
     const internalModifiers = useMemo(() => {
-      if (sameReferenceWidth) {
+      if (autoWidth) {
         const sameWidth = {
           name: 'sameWidth',
           enabled: true,
@@ -122,8 +135,16 @@ export const Menu: FC<
           requires: ['computeStyles'],
           fn: data => {
             const { width, left, right } = data.offsets.reference;
-            data.styles.width = width;
-            data.offsets.popper.width = width;
+            let menuWidth = width;
+
+            if (maxWidth && menuWidth > maxWidth) {
+              menuWidth = maxWidth;
+            } else if (minWidth && menuWidth < minWidth) {
+              menuWidth = minWidth;
+            }
+
+            data.styles.width = menuWidth;
+            data.offsets.popper.width = menuWidth;
             data.offsets.popper.left = left;
             data.offsets.popper.right = right;
 
@@ -135,7 +156,7 @@ export const Menu: FC<
       }
 
       return modifiers;
-    }, [modifiers, sameReferenceWidth]);
+    }, [modifiers, autoWidth, minWidth, maxWidth]);
 
     return (
       <ConnectedOverlay


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Menu component cannot pass Popper.js modifiers down through rdk's ConnectedOverlay. This makes it difficult to make the menu the same width as the reference element
Issue Number: N/A


## What is the new behavior?
Allow passing custom modifiers down from the Menu component as well as add a new prop `sameReferenceWidth` to add a pre-made custom modifier which sets the ConnectedOverlay's width to be the same as the reference.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
<img width="334" alt="Screen Shot 2022-09-15 at 9 39 01 PM" src="https://user-images.githubusercontent.com/6655992/190537953-3d684eda-8894-4c90-a253-b15d5bdb3685.png">
