### PR TITLE
better take passed in modifiers into consideration with autoWidth

### DIFF
--- a/src/Menu/Menu.tsx
+++ b/src/Menu/Menu.tsx
@@ -132,7 +132,9 @@ export const Menu: FC<
           enabled: true,
           order: 840,
           fn: data => {
-            const { width } = data.offsets.reference;
+            const { width, left, right } = data.offsets.reference;
+            const passedOffset = modifiers?.offset?.offset;
+            let passedXOffset = 0;
             let menuWidth = width;
 
             if (maxWidth && menuWidth > maxWidth) {
@@ -141,8 +143,19 @@ export const Menu: FC<
               menuWidth = minWidth;
             }
 
+            if (passedOffset) {
+              if (typeof passedOffset === 'number') {
+                passedXOffset = passedOffset;
+              } else {
+                const [skidding, distance] = passedOffset.split(',');
+                passedXOffset = parseInt(skidding.trim(), 10);
+              }
+            }
+
             data.styles.width = menuWidth;
             data.offsets.popper.width = menuWidth;
+            data.offsets.popper.left = left + passedXOffset;
+            data.offsets.popper.right = right + passedXOffset;
 
             return data;
           }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Menu with autoWidth has correct width, but the menu doesn't have the reference's left/right position making the menu not aligned with the reference
Issue Number: N/A


## What is the new behavior?
Manually set the menu's left/right position based on the reference's left/right position while also taking into consideration a menu's passed in modifier offset 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
